### PR TITLE
Removed lines that break NIR

### DIFF
--- a/criteria/nir.py
+++ b/criteria/nir.py
@@ -37,8 +37,6 @@ class Criterion(torch.nn.Module):
 
         ####
         self.optim_dict_list = []
-        self.T = torch.Tensor([opt.language_temp])
-        self.T = self.T.to(opt.device)
 
         self.proxies = None
         self.num_proxies = opt.n_classes

--- a/criteria/nir.py
+++ b/criteria/nir.py
@@ -2,7 +2,6 @@ import contextlib
 import copy
 import os
 
-import clip
 import numpy as np
 import torch, torch.nn as nn, torch.nn.functional as F
 


### PR DESCRIPTION
Hey Karsten!

I had to remove these 3 lines to be able to run your benchmark experiment on line 10 of `nir_benchmark_runs.sh`
Are they important? Or are these an artifact of something you were testing?